### PR TITLE
Set node value to true

### DIFF
--- a/rules/eslint/node/airbnb.js
+++ b/rules/eslint/node/airbnb.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   "env": {
-    "node": false
+    "node": true
   },
   "rules": {
     // enforces error handling in callbacks (node environment)


### PR DESCRIPTION
Sets env `node` value to `true`. The previous value which is `false` causes Node.js global variables (e.g. require) to be undefined.