### PR TITLE
Fixes defaults extensibility in configuration files

### DIFF
--- a/configurations/airbnb.js
+++ b/configurations/airbnb.js
@@ -2,15 +2,15 @@
 
 module.exports = {
   "extends": [
-    "../rules/eslint/best-practices/airbnb.js",
-    "../rules/eslint/errors/airbnb.js",
-    "../rules/eslint/es6/airbnb.js",
-    "../rules/eslint/legacy/airbnb.js",
-    "../rules/eslint/node/airbnb.js",
-    "../rules/eslint/strict/airbnb.js",
-    "../rules/eslint/style/airbnb.js",
-    "../rules/eslint/variables/airbnb.js",
-    "../rules/react/airbnb.js"
+    "defaults/rules/eslint/best-practices/airbnb",
+    "defaults/rules/eslint/errors/airbnb",
+    "defaults/rules/eslint/es6/airbnb",
+    "defaults/rules/eslint/legacy/airbnb",
+    "defaults/rules/eslint/node/airbnb",
+    "defaults/rules/eslint/strict/airbnb",
+    "defaults/rules/eslint/style/airbnb",
+    "defaults/rules/eslint/variables/airbnb",
+    "defaults/rules/react/airbnb"
   ],
   "parser": "babel-eslint",
   "env": {

--- a/configurations/eslint.js
+++ b/configurations/eslint.js
@@ -1,15 +1,13 @@
-"use strict";
-
 module.exports = {
   "extends": [
-    "../rules/eslint/best-practices/eslint.js",
-    "../rules/eslint/errors/eslint.js",
-    "../rules/eslint/es6/eslint.js",
-    "../rules/eslint/legacy/eslint.js",
-    "../rules/eslint/node/eslint.js",
-    "../rules/eslint/strict/eslint.js",
-    "../rules/eslint/style/eslint.js",
-    "../rules/eslint/variables/eslint.js"
+    "defaults/rules/eslint/best-practices/eslint",
+    "defaults/rules/eslint/errors/eslint",
+    "defaults/rules/eslint/es6/eslint",
+    "defaults/rules/eslint/legacy/eslint",
+    "defaults/rules/eslint/node/eslint",
+    "defaults/rules/eslint/strict/eslint",
+    "defaults/rules/eslint/style/eslint",
+    "defaults/rules/eslint/variables/eslint"
   ],
   "parser": "espree",
   "env": {

--- a/configurations/google.js
+++ b/configurations/google.js
@@ -2,14 +2,14 @@
 
 module.exports = {
   "extends": [
-    "../rules/eslint/best-practices/google.js",
-    "../rules/eslint/errors/google.js",
-    "../rules/eslint/es6/google.js",
-    "../rules/eslint/legacy/google.js",
-    "../rules/eslint/node/google.js",
-    "../rules/eslint/strict/google.js",
-    "../rules/eslint/style/google.js",
-    "../rules/eslint/variables/google.js",
+    "defaults/rules/eslint/best-practices/google",
+    "defaults/rules/eslint/errors/google",
+    "defaults/rules/eslint/es6/google",
+    "defaults/rules/eslint/legacy/google",
+    "defaults/rules/eslint/node/google",
+    "defaults/rules/eslint/strict/google",
+    "defaults/rules/eslint/style/google",
+    "defaults/rules/eslint/variables/google",
   ],
   "env": {},
   "ecmaFeatures": {},

--- a/configurations/off.js
+++ b/configurations/off.js
@@ -2,14 +2,14 @@
 
 module.exports = {
   "extends": [
-    "../rules/eslint/best-practices/off.js",
-    "../rules/eslint/errors/off.js",
-    "../rules/eslint/es6/off.js",
-    "../rules/eslint/legacy/off.js",
-    "../rules/eslint/node/off.js",
-    "../rules/eslint/strict/off.js",
-    "../rules/eslint/style/off.js",
-    "../rules/eslint/variables/off.js"
+    "defaults/rules/eslint/best-practices/off",
+    "defaults/rules/eslint/errors/off",
+    "defaults/rules/eslint/es6/off",
+    "defaults/rules/eslint/legacy/off",
+    "defaults/rules/eslint/node/off",
+    "defaults/rules/eslint/strict/off",
+    "defaults/rules/eslint/style/off",
+    "defaults/rules/eslint/variables/off"
   ],
   "env": {},
   "ecmaFeatures": {},

--- a/configurations/walmart/es5-browser.js
+++ b/configurations/walmart/es5-browser.js
@@ -1,9 +1,9 @@
 "use strict";
 
 module.exports = {
-  "extends": "./es5.js",
+  "extends": "defaults/configurations/walmart/es5",
   "env": {
     "browser": true
   }
 };
-        
+

--- a/configurations/walmart/es5-node.js
+++ b/configurations/walmart/es5-node.js
@@ -2,8 +2,8 @@
 
 module.exports = {
   "extends": [
-    "./es5.js",
-    "../../rules/eslint/node/walmart.js"
+    "defaults/configurations/walmart/es5",
+    "defaults/rules/eslint/node/walmart"
   ],
   "rules": {
     "strict": [2, "global"]

--- a/configurations/walmart/es5-test.js
+++ b/configurations/walmart/es5-test.js
@@ -2,12 +2,12 @@
 
 module.exports = {
   "extends": [
-    "./es5.js"
-  ], 
-  "env": { 
-    "mocha": true 
+    "defaults/configurations/walmart/es5",
+  ],
+  "env": {
+    "mocha": true
   },
-  "rules": { 
-    "max-nested-callbacks": 0 
-  } 
+  "rules": {
+    "max-nested-callbacks": 0
+  }
 };

--- a/configurations/walmart/es5.js
+++ b/configurations/walmart/es5.js
@@ -2,15 +2,15 @@
 
 module.exports = {
   "extends": [
-    "../../rules/eslint/best-practices/walmart.js",
-    "../../rules/eslint/errors/walmart.js",
-    "../../rules/eslint/es6/off.js",
-    "../../rules/eslint/legacy/walmart.js",
-    "../../rules/eslint/node/off.js",
-    "../../rules/eslint/strict/walmart.js",
-    "../../rules/eslint/style/walmart.js",
-    "../../rules/eslint/variables/walmart.js",
-    "../../rules/filenames/walmart.js"
+    "defaults/rules/eslint/best-practices/walmart",
+    "defaults/rules/eslint/errors/walmart",
+    "defaults/rules/eslint/es6/off",
+    "defaults/rules/eslint/legacy/walmart",
+    "defaults/rules/eslint/node/off",
+    "defaults/rules/eslint/strict/walmart",
+    "defaults/rules/eslint/style/walmart",
+    "defaults/rules/eslint/variables/walmart",
+    "defaults/rules/filenames/walmart"
   ],
   "env": {},
   "ecmaFeatures": {},

--- a/configurations/walmart/es6-browser.js
+++ b/configurations/walmart/es6-browser.js
@@ -1,9 +1,9 @@
 "use strict";
 
 module.exports = {
-  "extends": "./es6.js",
+  "extends": "defaults/configurations/walmart/es6",
 
-  "env": { 
-    "browser": true 
+  "env": {
+    "browser": true
   }
 };

--- a/configurations/walmart/es6-node.js
+++ b/configurations/walmart/es6-node.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   "extends": [
-    "./es6.js",
-    "../../rules/eslint/node/walmart.js"
+    "defaults/configurations/walmart/es6",
+    "defaults/rules/eslint/node/walmart"
   ]
 };

--- a/configurations/walmart/es6-react.js
+++ b/configurations/walmart/es6-react.js
@@ -2,8 +2,8 @@
 
 module.exports = {
   "extends": [
-    "./es6.js",
-    "../../rules/react/walmart.js"
+    "defaults/configurations/walmart/es6",
+    "defaults/rules/react/walmart"
   ],
   "globals": {
     "fetch": false

--- a/configurations/walmart/es6-test.js
+++ b/configurations/walmart/es6-test.js
@@ -1,11 +1,11 @@
 "use strict";
 
 module.exports = {
-  "extends": "./es6.js", 
-  "env": { 
-    "mocha": true 
+  "extends": "defaults/configurations/walmart/es6",
+  "env": {
+    "mocha": true
   },
-  "rules": { 
-    "max-nested-callbacks": 0 
-  } 
+  "rules": {
+    "max-nested-callbacks": 0
+  }
 };

--- a/configurations/walmart/es6.js
+++ b/configurations/walmart/es6.js
@@ -2,8 +2,8 @@
 
 module.exports = {
   "extends": [
-    "./es5.js",
-    "../../rules/eslint/es6/walmart.js"
+    "defaults/configurations/walmart/es5",
+    "defaults/rules/eslint/es6/walmart"
   ],
   "rules": {
     "strict": [2, "global"]

--- a/rules/eslint/best-practices/eslint.js
+++ b/rules/eslint/best-practices/eslint.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = {
   "rules": {
     // Enforces getter/setter pairs in objects

--- a/rules/eslint/best-practices/eslint.js
+++ b/rules/eslint/best-practices/eslint.js
@@ -1,5 +1,3 @@
-"use strict";
-
 module.exports = {
   "rules": {
     // Enforces getter/setter pairs in objects


### PR DESCRIPTION
Dug through `eslint/eslint` and found that the way extensibility works doesn't relative paths into consideration, it automatically assumes the `eslint-config` as the "root" and just joins the path based on the shared configuration.

### Testing:

Confirmed a local `.eslintrc` extending `defaults` and `defaults/*` did linting without errors in:
- Atom
- Shell running `node ./node_modules/eslint`

@ryan-roemer @baer 

Closes #34.