### PR TITLE
Turn on new rules added in eslint 1.5 -> 1.10

### DIFF
--- a/rules/eslint/best-practices/walmart.js
+++ b/rules/eslint/best-practices/walmart.js
@@ -27,7 +27,7 @@ module.exports = {
     // disallow use of arguments.caller or arguments.callee
     "no-caller": 2,
     // disallow lexical declarations in case clauses
-    "no-case-declarations": 0,
+    "no-case-declarations": 2,
     // disallow division operators explicitly at beginning of regular expression
     "no-div-regex": 0,
     // disallow else after a return in an if
@@ -35,7 +35,7 @@ module.exports = {
     // disallow use of labels for anything other then loops and switches
     "no-empty-label": 2,
     // disallow use of empty destructuring patterns
-    "no-empty-pattern": 0,
+    "no-empty-pattern": 2,
     // disallow comparisons to null without a type-checking operator
     "no-eq-null": 0,
     // disallow use of eval()
@@ -63,7 +63,7 @@ module.exports = {
     // disallow creation of functions within loops
     "no-loop-func": 2,
     // disallow the use of magic numbers
-    "no-magic-numbers": 0,
+    "no-magic-numbers": 2,
     // disallow use of multiple spaces
     "no-multi-spaces": 2,
     // disallow use of multiline strings

--- a/rules/eslint/es6/walmart.js
+++ b/rules/eslint/es6/walmart.js
@@ -19,7 +19,7 @@ module.exports = {
     // enforce the spacing around the * in generator functions
     "generator-star-spacing": 2,
     // disallow arrow functions where a condition is expected
-    "no-arrow-condition": 0,
+    "no-arrow-condition": 2,
     // disallow modifying variables of class declarations
     "no-class-assign": 2,
     // disallow modifying variables that are declared using const

--- a/rules/eslint/style/walmart.js
+++ b/rules/eslint/style/walmart.js
@@ -41,7 +41,7 @@ module.exports = {
     // specify the maximum depth that blocks can be nested
     "max-depth": [2, 4],
     // specify the maximum length of a line in your program
-    "max-len": [2, 100, 2],
+    "max-len": [2, 100, 2, {"ignoreUrls": true, "ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\\("}],
     // specify the maximum depth callbacks can be nested
     "max-nested-callbacks": [2, 3],
     // limits the number of parameters that can be used in the function declaration.
@@ -117,9 +117,9 @@ module.exports = {
     // require or disallow space before blocks
     "space-before-blocks": [2, "always"],
     // require or disallow space before function opening parenthesis
-    "space-before-function-paren": [2, {anonymous: "always", named: "never" }],
-    // equire a space before certain keywords (fixable)
-    "space-before-keywords": 0,
+    "space-before-function-paren": [2, {"anonymous": "always", "named": "never" }],
+    // require a space before certain keywords (fixable)
+    "space-before-keywords": [2, "always"],
     // require or disallow spaces inside parentheses
     "space-in-parens": [2, "never"],
     // require spaces around operators


### PR DESCRIPTION
Turn on (most of) the rules added as a part of Moving from ESLint 1.5 -> 1.10. See #42 for further discussion. 

The only rule left off that could use a bit of discussion is [enforcing JSDoc](https://github.com/walmartlabs/eslint-config-defaults/pull/42/files#r48374080)

@ryan-roemer @rgerstenberger @jherr @chaseadamsio @exogen